### PR TITLE
fix: remove Lovable tagger watermark

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.9.0",
-    "lovable-tagger": "^1.1.7",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,19 +1,15 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
-import { componentTagger } from "lovable-tagger";
-
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
+export default defineConfig(() => ({
   server: {
     host: "::",
     port: 8080,
   },
   plugins: [
     react(),
-    mode === 'development' &&
-    componentTagger(),
-  ].filter(Boolean),
+  ],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
Removes the `lovable-tagger` dev dependency and its `componentTagger()` plugin from `vite.config.ts`.

This package adds a visual overlay/badge on components in development mode (the "Lovable cards" watermark). Since this is no longer needed, removing it keeps the dev build clean.

**Changes:**
- `vite.config.ts`: removed `componentTagger` import and plugin; simplified config signature (no longer needs `mode`)
- `package.json`: removed `lovable-tagger` from `devDependencies`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused development tooling dependency.
  * Simplified build configuration to streamline the development workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WildestAI/wildest-ai-website/pull/3?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->